### PR TITLE
Added Karjalankartta map

### DIFF
--- a/World/Europe/FI/Karjalankartta.xml
+++ b/World/Europe/FI/Karjalankartta.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+	<name>Karjalankartta</name>
+	<url>http://www.karjalankartat.fi/wms/8b42201cc218b9cd6c6ef9321e1d40f0</url>
+	<copyright>© Maanmittauslaitos</copyright>
+	<layer>karjalankartat:topo20k_group</layer>
+	<crs axis="yx">EPSG:2394</crs>
+</map>


### PR DESCRIPTION
[Karelian Maps](https://www.maanmittauslaitos.fi/en/e-services/karelian-maps):
> There are maps of the Karelian Isthmus and Ladoga Karelia drawn up by the National Land Survey and the Topographic Service of the Finnish military before 1939.
1. The map works with the latest released GPXSee version:
![screenshot1](https://user-images.githubusercontent.com/688044/38577655-38d1b032-3d0a-11e8-82f3-2243d00587ad.jpg)
2. The map validates against the latest map xsd schema:
```sh
$ wget http://www.gpxsee.org/map/1/map.xsd
$ xmllint -schema map.xsd Karjalankartta.xml --noout
Karjalankartta.xml validates
```
3. Using the map data in GPXSee is not prohibited by the map license:
[Terms of use](https://www.maanmittauslaitos.fi/en/e-services/karelian-maps#terms-of-use)