### PR TITLE
Added Topografisk Norgeskart map

### DIFF
--- a/World/Europe/NO/Norgeskart.xml
+++ b/World/Europe/NO/Norgeskart.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+	<name>Topografisk Norgeskart</name>
+	<url>http://openwms.statkart.no/skwms1/wms.topo4</url>
+	<copyright>Norwegian Mapping Authority (CC BY 4.0)</copyright>
+	<layer>topo4_WMS</layer>
+	<crs>EPSG:25833</crs>
+</map>


### PR DESCRIPTION
1. The map works with the latest released GPXSee version:
![screenshot1](https://user-images.githubusercontent.com/688044/38733941-7daaa6c2-3f2c-11e8-81e1-3f0ac92c67f3.jpg)
2. The map validates against the latest map xsd schema:
```sh
$ wget http://www.gpxsee.org/map/1/map.xsd
$ xmllint -schema map.xsd Norgeskart.xml --noout
Norgeskart.xml validates
```
3. Using the map data in GPXSee is not prohibited by the map license:
[Topografisk Norgeskart](https://kartkatalog.geonorge.no/metadata/kartverket/topografisk-norgeskart/f004268c-d4a1-4801-91cb-daa46236fab7), CC BY 4.0.