### PR TITLE
Added MapAnt map

### DIFF
--- a/World/Europe/FI/MapAnt.xml
+++ b/World/Europe/FI/MapAnt.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+	<name>MapAnt</name>
+	<url>http://wmts.mapant.fi/wmts.php</url>
+	<copyright>Map data: National Land Survey of Finland (CC BY 4.0) | Rendering: MapAnt (CC BY 4.0)</copyright>
+	<layer>MapAnt.fi</layer>
+	<set>ETRS-TM35FIN</set>
+</map>


### PR DESCRIPTION
> MapAnt is a gigantic orienteering map covering almost all of Finland. It was automatically generated based on the publically available laser scanning data and topographic maps from the National Land Survey of Finland.

- [What is MapAnt?](http://www.mapant.fi/about.php)
- [National Land Survey open data CC 4.0 licence](https://www.maanmittauslaitos.fi/en/opendata-licence-cc40)

[WMTS (Web Map Tile Service) and WMS (Web Map Service)](http://www.mapant.fi/about.php#WMTS):
> From December 2017 onwards MapAnt.fi map can be accessed via WMTS and WMS. There is currently three alternatives available:
> - (1) WMTS, TM35FIN (EPSG:3067) with JHS180 compatible tiles. Here is [EPSG:3067 WMTS Capabilities](http://wmts.mapant.fi/wmts.xml) and here is example how to use it in Leaflet.js. **This is preferred alternative, it is fasteest and has best image quality.**
> - (2) WMTS, Web Mercator (EPSG:3857, EPSG:900913) popularized by web services such as Google and OSM. Here is [Web Mercator WMTS Capabilities](http://wmts.mapant.fi/wmts_EPSG3857.xml) and here is Leaflet.js example page. Note, transformation to this coordinate system is made on-the-fly so there is compromises in image quality and response times.
> - (3) WMS, TM35FIN (EPSG:3067) only. Here is [WMS](http://wms.mapant.fi/wms.php) URL. Maximum image size is 4000 x 4000 pixels. Image quality is best if requested resolution is a power of 2 (1,2,4,8 ... m/pixel) and image is size below 3000x3000 pixels. Please don't overload WMS service with lots of big requests, we would like to keep this available to provide easy way to access data with clients supporting WMS but not supporting WMTS, such as Ocad

~I had to choose the second option (WMTS, Web Mercator).~
~What about the first option (WMTS, TM35FIN), see tumic0/GPXSee#104.~