### PR TITLE
Added marshruty.ru map

### DIFF
--- a/World/marshruty.ru.xml
+++ b/World/marshruty.ru.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1">
+	<name>marshruty.ru</name>
+	<url>https://maps.marshruty.ru/ml.ashx?x=$x&amp;y=$y&amp;z=$z&amp;i=1&amp;al=1</url>
+	<copyright>Map data: General Staff of USSR, GOSGISCENTR</copyright>
+</map>


### PR DESCRIPTION
[marshruty.ru](https://www.marshruty.ru/Maps/Maps.aspx) is an aggregator of Topo maps produced by _General Staff of USSR_ ("Genshtab") and _FGUP "GOSGISCENTR"_ (new "Genshtab") at different times. It covers Russia and some other countries, but the availability of maps and scales (0.25km, 0.5km, 1km, 2km) depends on the place.

1. The map works with the latest released GPXSee version:
![screenshot1](https://user-images.githubusercontent.com/688044/45263475-979fd900-b432-11e8-95fc-cd11b22422bf.png)
2. The map validates against the latest map xsd schema:
```sh
$ wget http://www.gpxsee.org/map/1/map.xsd
$ xmllint -schema map.xsd World/marshruty.ru.xml --noout
World/marshruty.ru.xml validates
```
3. Using the map data in GPXSee is not prohibited by the map license:
No info about licenses.