### PR TITLE
Update maps of the National Land Survey of Finland

### DIFF
--- a/World/Europe/FI/Ilmakuva.xml
+++ b/World/Europe/FI/Ilmakuva.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
-	<name>Maastokartta (Topographic map)</name>
+	<name>Ilmakuva (Aerial image)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
-	<layer>maastokartta</layer>
+	<format>image/jpeg</format>
+	<layer>ortokuva</layer>
 	<set>ETRS-TM35FIN</set>
 </map>

--- a/World/Europe/FI/Karjalankartta.xml
+++ b/World/Europe/FI/Karjalankartta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1" type="WMS">
-	<name>Karjalankartta</name>
+	<name>Karjalankartta (Maps of Karelia)</name>
 	<url>http://www.karjalankartat.fi/wms/8b42201cc218b9cd6c6ef9321e1d40f0</url>
-	<copyright>© Maanmittauslaitos</copyright>
+	<copyright>Map data: National Land Survey of Finland</copyright>
 	<layer>karjalankartat:topo20k_group</layer>
 	<crs>EPSG:2394</crs>
 </map>

--- a/World/Europe/FI/Rinnevarjostus.xml
+++ b/World/Europe/FI/Rinnevarjostus.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
-	<name>Maastokartta (Topographic map)</name>
+	<name>Rinnevarjostus (Hillshade)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
-	<layer>maastokartta</layer>
+	<layer>korkeusmalli_vinovalo</layer>
 	<set>ETRS-TM35FIN</set>
 </map>

--- a/World/Europe/FI/Selkokartta.xml
+++ b/World/Europe/FI/Selkokartta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
-	<name>Maastokartta (Topographic map)</name>
+	<name>Selkokartta (Plain map)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
-	<layer>maastokartta</layer>
+	<layer>selkokartta</layer>
 	<set>ETRS-TM35FIN</set>
 </map>


### PR DESCRIPTION
Added main maps of the National Land Survey of Finland:

| Name (fi) | Name (en) | Map data |
| --- | ---| ---|
| [Maastokartta](https://www.maanmittauslaitos.fi/kartat-ja-paikkatieto/asiantuntevalle-kayttajalle/tuotekuvaukset/maastokarttasarja-rasteri)  | [Topographic map](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/topographic-map-series-raster) | National Land Survey open data CC 4.0 licence |
| [Selkokartta](https://www.maanmittauslaitos.fi/kartat-ja-paikkatieto/asiantuntevalle-kayttajalle/tuotekuvaukset/selkokarttasarja-rasteri) | [Plain map](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/plain-map-series-raster) | National Land Survey open data CC 4.0 licence |
| [Ilmakuva](https://www.maanmittauslaitos.fi/kartat-ja-paikkatieto/asiantuntevalle-kayttajalle/tuotekuvaukset/ortokuva) | [Aerial image](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/orthophotos) | National Land Survey open data CC 4.0 licence |
| [Rinnevarjostus](https://www.maanmittauslaitos.fi/kartat-ja-paikkatieto/asiantuntevalle-kayttajalle/tuotekuvaukset/rinnevarjostus) | [Hillshade](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/expert-users/product-descriptions/hillshade) | National Land Survey open data CC 4.0 licence |
| [Vanha Karjalan kartta](https://www.maanmittauslaitos.fi/kartat-ja-paikkatieto/kartat/katsele-karttoja/nain-saat-vanhat-karjalan-kartat-kayttoosi) | [Old map of Karelia](https://www.maanmittauslaitos.fi/en/maps-and-spatial-data/maps/view-maps/how-start-using-old-maps-karelia) | National Land Survey ([terms of use](http://www.karjalankartat.fi/termsofuse.html)) |

All maps can also be found on:
* [Maanmittauslaitoksen karttapaikka](https://asiointi.maanmittauslaitos.fi/karttapaikka/)
* [Metsähallituksen retkikartta](https://retkikartta.fi/)