### PR TITLE
Fix failed xml validations

### DIFF
--- a/World/Europe/BE/ngi.xml
+++ b/World/Europe/BE/ngi.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>NGI</name>
 	<url type="REST">http://www.ngi.be/cartoweb/1.0.0/WMTSCapabilities.xml</url>
 	<copyright>Nationaal Geografisch Instituut</copyright>

--- a/World/Europe/CH/OpenStreetMap-Swiss-Style.xml
+++ b/World/Europe/CH/OpenStreetMap-Swiss-Style.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.1">
+<map xmlns="http://www.gpxsee.org/map/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.1 https://www.gpxsee.org/map/1.1/map.xsd">
 	<name>OSM Switzerland Swiss Style</name>
 	<url>https://tile.osm.ch/osm-swiss-style/$z/$x/$y.png</url>
 	<zoom min="6"/>

--- a/World/Europe/CH/OpenStreetMap-Switzerland.xml
+++ b/World/Europe/CH/OpenStreetMap-Switzerland.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.1">
+<map xmlns="http://www.gpxsee.org/map/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.1 https://www.gpxsee.org/map/1.1/map.xsd">
 	<name>OSM Switzerland</name>
 	<url>https://tile.osm.ch/switzerland/$z/$x/$y.png</url>
 	<zoom min="6"/>

--- a/World/Europe/CH/Swisstopo-Aerial.tpl
+++ b/World/Europe/CH/Swisstopo-Aerial.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMS">
 	<name>Swisstopo Aerial</name>
 	<url>https://wms.swisstopo.admin.ch</url>
 	<copyright>Federal Topographical Office</copyright>

--- a/World/Europe/CH/Swisstopo.tpl
+++ b/World/Europe/CH/Swisstopo.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMS">
 	<name>Swisstopo</name>
 	<url>https://wms.swisstopo.admin.ch</url>
 	<copyright>Federal Topographical Office</copyright>

--- a/World/Europe/CZ/CUZK-ortofoto.xml
+++ b/World/Europe/CZ/CUZK-ortofoto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>ČÚZK - Ortofoto</name>
 	<url>http://geoportal.cuzk.cz/WMTS_ORTOFOTO/WMTService.aspx</url>
 	<copyright>© ČÚZK</copyright>

--- a/World/Europe/CZ/CUZK-zm.xml
+++ b/World/Europe/CZ/CUZK-zm.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>ČÚZK - Základní mapy</name>
 	<url>http://geoportal.cuzk.cz/WMTS_ZM/WMTService.aspx</url>
 	<copyright>© ČÚZK</copyright>

--- a/World/Europe/CZ/Poloha.Net.xml
+++ b/World/Europe/CZ/Poloha.Net.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>Poloha.Net</name>
 	<url>http://tile.poloha.net/$z/$x/$y.png</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Poloha.Net</copyright>

--- a/World/Europe/ES/IGN-mapa-raster.xml
+++ b/World/Europe/ES/IGN-mapa-raster.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Cartografía raster del IGN</name>
 	<url>http://www.ign.es/wmts/mapa-raster</url>
 	<copyright>© Instituto Geográfico Nacional</copyright>

--- a/World/Europe/FI/Ilmakuva.xml
+++ b/World/Europe/FI/Ilmakuva.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Ilmakuva (Aerial image)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>

--- a/World/Europe/FI/Karjalankartta.xml
+++ b/World/Europe/FI/Karjalankartta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMS">
 	<name>Karjalankartta (Maps of Karelia)</name>
 	<url>http://www.karjalankartat.fi/wms/8b42201cc218b9cd6c6ef9321e1d40f0</url>
 	<copyright>Map data: National Land Survey of Finland</copyright>

--- a/World/Europe/FI/Maastokartta.xml
+++ b/World/Europe/FI/Maastokartta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Maastokartta (Topographic map)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>

--- a/World/Europe/FI/MapAnt.xml
+++ b/World/Europe/FI/MapAnt.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>MapAnt</name>
 	<url>http://wmts.mapant.fi/wmts.php</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0) | Rendering: MapAnt (CC BY 4.0)</copyright>

--- a/World/Europe/FI/Rinnevarjostus.xml
+++ b/World/Europe/FI/Rinnevarjostus.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Rinnevarjostus (Hillshade)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>

--- a/World/Europe/FI/Selkokartta.xml
+++ b/World/Europe/FI/Selkokartta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Selkokartta (Plain map)</name>
 	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>

--- a/World/Europe/IS/NLS_Atlas.xml
+++ b/World/Europe/IS/NLS_Atlas.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Iceland Atlas</name>
 	<url>https://gis.lmi.is/mapcache/wmts</url>
 	<copyright>Map data: National Land Survey of Iceland</copyright>

--- a/World/Europe/IS/NLS_Landscape.xml
+++ b/World/Europe/IS/NLS_Landscape.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Iceland Landscape</name>
 	<url>https://gis.lmi.is/mapcache/wmts</url>
 	<copyright>Map data: National Land Survey of Iceland</copyright>

--- a/World/Europe/IS/NLS_Map.xml
+++ b/World/Europe/IS/NLS_Map.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>Iceland Map</name>
 	<url>https://gis.lmi.is/mapcache/wmts</url>
 	<copyright>Map data: National Land Survey of Iceland</copyright>

--- a/World/Europe/NO/Norgeskart.xml
+++ b/World/Europe/NO/Norgeskart.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMS">
 	<name>Topografisk Norgeskart</name>
 	<url>http://openwms.statkart.no/skwms1/wms.topo4</url>
 	<copyright>Norwegian Mapping Authority (CC BY 4.0)</copyright>

--- a/World/Europe/PL/UMP-pcPL.xml
+++ b/World/Europe/PL/UMP-pcPL.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="OSM">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="OSM">
   <name>UMP-pcPL</name>
   <url>http://tiles.ump.waw.pl/ump_tiles/$z/$x/$y.png</url>
   <copyright>© UMP-pcPL | http://ump.waw.pl/ (CC BY-SA 3.0)</copyright>

--- a/World/Europe/RU/nakarte-adraces.xml
+++ b/World/Europe/RU/nakarte-adraces.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>Races</name>
 	<url>https://tiles.nakarte.tk/adraces/$z/$x/$y</url>
 </map>

--- a/World/Europe/RU/nakarte-ggc1000.xml
+++ b/World/Europe/RU/nakarte-ggc1000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>GGC 1km</name>
 	<url>https://tiles.nakarte.tk/ggc1000/$z/$x/$y</url>
 	<copyright>Map data: GOSGISCENTR</copyright>

--- a/World/Europe/RU/nakarte-ggc2000.xml
+++ b/World/Europe/RU/nakarte-ggc2000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>GGC 2km</name>
 	<url>https://tiles.nakarte.tk/ggc2000/$z/$x/$y</url>
 	<copyright>Map data: GOSGISCENTR</copyright>

--- a/World/Europe/RU/nakarte-ggc250.xml
+++ b/World/Europe/RU/nakarte-ggc250.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>GGC 250m</name>
 	<url>https://tiles.nakarte.tk/ggc250/$z/$x/$y</url>
 	<copyright>Map data: GOSGISCENTR</copyright>

--- a/World/Europe/RU/nakarte-ggc500.xml
+++ b/World/Europe/RU/nakarte-ggc500.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>GGC 500m</name>
 	<url>https://tiles.nakarte.tk/ggc500/$z/$x/$y</url>
 	<copyright>Map data: GOSGISCENTR</copyright>

--- a/World/Europe/RU/nakarte-osport.xml
+++ b/World/Europe/RU/nakarte-osport.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>O-sport</name>
 	<url>https://tiles.nakarte.tk/osport/$z/$x/$y</url>
 </map>

--- a/World/Europe/RU/nakarte-topo1000.xml
+++ b/World/Europe/RU/nakarte-topo1000.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>Topo 1km</name>
 	<url>https://tiles.nakarte.tk/topo1000/$z/$x/$y</url>
 	<copyright>Map data: General Staff of the Armed Forces of the USSR</copyright>

--- a/World/Europe/RU/nakarte-topo250.xml
+++ b/World/Europe/RU/nakarte-topo250.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>Topo 250m</name>
 	<url>https://tiles.nakarte.tk/topo250/$z/$x/$y</url>
 	<copyright>Map data: General Staff of the Armed Forces of the USSR</copyright>

--- a/World/Europe/RU/nakarte-topo500.xml
+++ b/World/Europe/RU/nakarte-topo500.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.2" type="TMS">
+<map xmlns="http://www.gpxsee.org/map/1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.2 https://www.gpxsee.org/map/1.2/map.xsd" type="TMS">
 	<name>Topo 500m</name>
 	<url>https://tiles.nakarte.tk/topo500/$z/$x/$y</url>
 	<copyright>Map data: General Staff of the Armed Forces of the USSR</copyright>

--- a/World/Europe/SK/GKU-ZBGIS.xml
+++ b/World/Europe/SK/GKU-ZBGIS.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>GKÚ - ZBGIS</name>
 	<url>https://zbgisws.skgeodesy.sk/zbgis_wmts/service.svc/get</url>
 	<copyright>ZBGIS®, Úrad geodézie, kartografie a katastra Slovenskej republiky</copyright>

--- a/World/Europe/SK/GKU-ortofoto.xml
+++ b/World/Europe/SK/GKU-ortofoto.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1" type="WMTS">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd" type="WMTS">
 	<name>GKÚ - Ortofotomozaika</name>
 	<url>https://zbgisws.skgeodesy.sk/zbgis_ortofoto_wmts/service.svc/get</url>
 	<copyright>ZBGIS®, Úrad geodézie, kartografie a katastra Slovenskej republiky</copyright>

--- a/World/Europe/map1.eu.xml
+++ b/World/Europe/map1.eu.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>map1.eu</name>
 	<url>http://beta.map1.eu/tiles/$z/$x/$y.jpg</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Pavel Klinger (CC BY-NC-ND 3.0)</copyright>

--- a/World/FrauenhoferIOSB.xml
+++ b/World/FrauenhoferIOSB.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>OSMorg (IOSB)</name>
 	<url>https://tile.iosb.fraunhofer.de/tiles/osmorg/$z/$x/$y.png</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: Fraunhofer IOSB</copyright>

--- a/World/HikeBikeMap.xml
+++ b/World/HikeBikeMap.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>HikeBikeMap</name>
 	<url>http://a.tiles.wmflabs.org/hikebike/$z/$x/$y.png</url>
 	<copyright>Map data: © OpenStreetMap contributors, ODbL | Rendering: © HikeBikeMap.org, CC-BY-SA</copyright>

--- a/World/OpenStreetMap-HiDPI.xml
+++ b/World/OpenStreetMap-HiDPI.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1.1">
+<map xmlns="http://www.gpxsee.org/map/1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.1 https://www.gpxsee.org/map/1.1/map.xsd">
 	<name>Open Street Map - HiDPI</name>
 	<url>https://a.osm.rrze.fau.de/osmhd/$z/$x/$y.png</url>
 	<tilePixelRatio>2</tilePixelRatio>

--- a/World/Thunderforest-Landscape.tpl
+++ b/World/Thunderforest-Landscape.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>Landscape</name>
 	<url>http://a.tile.thunderforest.com/landscape/$z/$x/$y.png?apikey=insert-your-apikey-here</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Thunderforest (CC-BY-SA 2.0)</copyright>

--- a/World/Thunderforest-OpenCycleMap.tpl
+++ b/World/Thunderforest-OpenCycleMap.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>OpenCycleMap</name>
 	<url>http://a.tile.thunderforest.com/cycle/$z/$x/$y.png?apikey=insert-your-apikey-here</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Thunderforest (CC-BY-SA 2.0)</copyright>

--- a/World/Thunderforest-Outdoors.tpl
+++ b/World/Thunderforest-Outdoors.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>Outdoors</name>
 	<url>http://a.tile.thunderforest.com/outdoors/$z/$x/$y.png?apikey=insert-your-apikey-here</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Thunderforest (CC-BY-SA 2.0)</copyright>

--- a/World/Thunderforest-Transport.tpl
+++ b/World/Thunderforest-Transport.tpl
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>Transport</name>
 	<url>http://a.tile.thunderforest.com/transport/$z/$x/$y.png?apikey=insert-your-apikey-here</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Thunderforest (CC-BY-SA 2.0)</copyright>

--- a/World/heidelberg.xml
+++ b/World/heidelberg.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>GIScience Heidelberg</name>
 	<url>https://korona.geog.uni-heidelberg.de/tiles/roads/x=$x&amp;y=$y&amp;z=$z</url>
 	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © GIScience Heidelberg (CC-SA)</copyright>

--- a/World/marshruty.ru.xml
+++ b/World/marshruty.ru.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>marshruty.ru</name>
 	<url>https://maps.marshruty.ru/ml.ashx?x=$x&amp;y=$y&amp;z=$z&amp;i=1&amp;al=1</url>
-	<copyright>Map data: General Staff of USSR, GOSGISCENTR</copyright>
+	<copyright>Map data: General Staff of the Armed Forces of the USSR, GOSGISCENTR</copyright>
 </map>

--- a/World/unesco.xml
+++ b/World/unesco.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<map xmlns="http://www.gpxsee.org/map/1">
+<map xmlns="http://www.gpxsee.org/map/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.gpxsee.org/map/1.0 https://www.gpxsee.org/map/1.0/map.xsd">
 	<name>UNESCO</name>
 	<url>https://en.unesco.org/tiles/$z/$x/$y.png</url>
 	<copyright>© UNESCO</copyright>


### PR DESCRIPTION
There are two points here:

1. Some XML validations fail after `xmlns` was modified in `map/1/map.xsd` (https://github.com/tumic0/GPXSee/commit/4a80f5a613cc8320673e568cc27571ba3962bfdd#diff-ec4a8bbb88358571f4a2abe337396e5e):
```bash
$ cat << 'EOF' > validate.sh
#!/bin/sh

find . -type f \( -iname \*.xml -o -iname \*.tpl \) | \
  xargs -L1 -P0 -I {} bash -c \
  'xmllint -schema <('`
    `'curl -s `xml sel -t -v "namespace-uri(/*)" $1`/map.xsd'`
    `') $1 --noout' _ {} 2>&1 | sort
EOF
$ chmod +x validate.sh
$ ./validate.sh | tail -n 2
./World/unesco.xml:2: element map: Schemas validity error : Element '{http://www.gpxsee.org/map/1}map': No matching global declaration available for the validation root.
./World/unesco.xml fails to validate
$ ./validate.sh | grep -c "validates"
12
$ ./validate.sh  | grep -c "fails to validate"
30
```
2. Allow XML editors to validate the XML file against its specified `xsi:schemaLocation` on the fly (no need to run `validate.sh` script before commit).

Bellow is an example from _Visual Studio Code_ (with _XML Tools_ extension):

- We have some error here (`foo="bar"`), but editor have no idea about it:
![screenshot1](https://user-images.githubusercontent.com/688044/46721649-357a0400-cc7c-11e8-8df7-5418a4c71cdc.jpg)
- Let's add `xmlns:xsi` and `xsi:schemaLocation` attributes, much better:
![screenshot2](https://user-images.githubusercontent.com/688044/46721650-357a0400-cc7c-11e8-9b6f-9edc8e6b30bb.jpg)
- Let's fix `xmlns` (see point #&#xfeff;1), and now `foo="bar"` highlighted as error, profit:
![screenshot3](https://user-images.githubusercontent.com/688044/46721651-357a0400-cc7c-11e8-9e76-2e047a29fe21.jpg)
