### PR TITLE
Add topographic maps of New Zealand

### DIFF
--- a/World/Oceania/NZ/NZTopoMap250.xml
+++ b/World/Oceania/NZ/NZTopoMap250.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="TMS">
+	<name>NZ Topo Map 250</name>
+	<url>http://tiles-1.topomap.co.nz/tiles-topo250-20180508/$z-$x-$y.png</url>
+	<zoom min="5" max="12"/>
+	<bounds left="165.00" right="179.00" bottom="-48.00" top="-34.00"/>
+	<copyright>Map data: Land Information New Zealand (LINZ)</copyright>
+</map>

--- a/World/Oceania/NZ/NZTopoMap50.xml
+++ b/World/Oceania/NZ/NZTopoMap50.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="TMS">
+	<name>NZ Topo Map 50</name>
+	<url>http://tiles-1.topomap.co.nz/tiles-topo50-20181002/$z-$x-$y.png</url>
+	<zoom min="13" max="15"/>
+	<bounds left="165.00" right="179.00" bottom="-48.00" top="-34.00"/>
+	<copyright>Map data: Land Information New Zealand (LINZ)</copyright>
+</map>


### PR DESCRIPTION
> NZ Topo Map is an interactive topographic map of New Zealand using the official LINZ's 1:50,000 / Topo50 and 1:250,000 / Topo250 maps.

NZ Topo Map 50:
![scr50](https://user-images.githubusercontent.com/688044/49942480-74376f00-fef6-11e8-918d-90db13076c8f.jpg)
NZ Topo Map 250:
![scr250](https://user-images.githubusercontent.com/688044/49942481-74376f00-fef6-11e8-8f94-ee343290a4a1.jpg)
Source: https://www.topomap.co.nz/