### PR TITLE
Added Svalbard / Jan Mayen maps

### DIFF
--- a/World/Europe/NO/JanMayen_Basiskart.xml
+++ b/World/Europe/NO/JanMayen_Basiskart.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="WMTS">
+	<name>Jan Mayen Topography</name>
+	<url>https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_JanMayen_WMTS_25833/MapServer/WMTS</url>
+	<copyright>© Norwegian Polar Institute, CC BY 4.0</copyright>
+	<format>image/jpgpng</format>
+	<layer>Basisdata_NP_Basiskart_JanMayen_WMTS_25833</layer>
+	<set>default028mm</set>
+</map>

--- a/World/Europe/NO/Svalbard_Basiskart.xml
+++ b/World/Europe/NO/Svalbard_Basiskart.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="WMTS">
+	<name>Svalbard Topography</name>
+	<url>https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Basiskart_Svalbard_WMTS_25833/MapServer/WMTS</url>
+	<copyright>© Norwegian Polar Institute, CC BY 4.0</copyright>
+	<format>image/jpgpng</format>
+	<layer>Basisdata_NP_Basiskart_Svalbard_WMTS_25833</layer>
+	<set>default028mm</set>
+</map>

--- a/World/Europe/NO/Svalbard_Ortofoto.xml
+++ b/World/Europe/NO/Svalbard_Ortofoto.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="WMTS">
+	<name>Svalbard Orthophoto</name>
+	<url>https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Ortofoto_Svalbard_WMTS_25833/MapServer/WMTS</url>
+	<copyright>© Norwegian Polar Institute, CC BY-NC 4.0</copyright>
+	<format>image/jpgpng</format>
+	<layer>Basisdata_NP_Ortofoto_Svalbard_WMTS_25833</layer>
+	<set>default028mm</set>
+</map>

--- a/World/Europe/NO/Svalbard_Satellitt.xml
+++ b/World/Europe/NO/Svalbard_Satellitt.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.3" type="WMTS">
+	<name>Svalbard Satellite Imagery</name>
+	<url>https://geodata.npolar.no/arcgis/rest/services/Basisdata/NP_Satellitt_Svalbard_WMTS_25833/MapServer/WMTS</url>
+	<copyright>© Norwegian Polar Institute / USGS Landsat, CC BY 4.0</copyright>
+	<format>image/jpgpng</format>
+	<layer>Basisdata_NP_Satellitt_Svalbard_WMTS_25833</layer>
+	<set>default028mm</set>
+</map>


### PR DESCRIPTION
### Maps
* Svalbard Topography
* Svalbard Orthophoto
* Svalbard Satellite Imagery
* Jan Mayen Topography
### Examples
* [Beerenberg](https://en.wikipedia.org/wiki/Beerenberg) (the highest point of Jan Mayen, 2277 m):
![scr1](https://user-images.githubusercontent.com/688044/58163849-60561d00-7c8d-11e9-9b24-856fc1d19aa0.jpg)
* [Longyearbyen](https://en.wikipedia.org/wiki/Longyearbyen) (the largest city on Svalbard):
![scr2](https://user-images.githubusercontent.com/688044/58163851-60561d00-7c8d-11e9-942b-b20533391048.jpg)
* [Newtontoppen](https://en.wikipedia.org/wiki/Newtontoppen) (the highest point on Svalbard, 1713 m):
![scr3](https://user-images.githubusercontent.com/688044/58163852-60561d00-7c8d-11e9-85bc-98ee798a06a6.jpg)
### Links
* [Norwegian Polar Institute Map Data and Services](https://geodata.npolar.no/#basemap-services)
* [Terms of Use](https://geodata.npolar.no/bruksvilkar/)