### PR TITLE
Added GSI basemap of Japan

### DIFF
--- a/World/Asia/JP/GSI-basemap.xml
+++ b/World/Asia/JP/GSI-basemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.4">
+	<name>Geographical Institute Tile (標準地図)</name>
+	<url>https://cyberjapandata.gsi.go.jp/xyz/std/$z/$x/$y.png</url>
+	<zoom min="5" max="18"/>
+	<bounds left="122.00" right="154.00" bottom="20.00" top="46.00"/>
+	<copyright>© Geospatial Information Authority of Japan (GSI), U.S. Geological Survey (USGS), British Oceanographic Data Centre (BODC)</copyright>
+</map>


### PR DESCRIPTION
Homepage: https://cyberjapandata.gsi.go.jp
[Terms of use](https://maps.gsi.go.jp/development/ichiran.html):
> 地理院タイルをウェブサイトやソフトウェア、アプリケーション上でリアルタイムに読み込んで利用する場合、地理院タイルは出典の明示のみで申請不要でご利用いただけます。
出典は、「国土地理院」または「地理院タイル」等と記載していただき、地理院タイル一覧ページ https://maps.gsi.go.jp/development/ichiran.html へのリンクを付けてください。

> If you want to use the Geographical Institution tile on a website, software, or application in real time, you can use the Geographical Institution tile without specifying the source.
The source should be described as “Geographical Survey Institute” or “Geographical Institute Tile”, etc., with a link to the Geographical Survey Institute Tile List Page please.

Zooms 5~8 require additional copyright statements:
> 尚、本地図（小縮尺地図（500万分1日本とその周辺））を利用する場合は、「国土地理院コンテンツ利用規約」で定める方法での出所明示に加え、以下の出所も合わせて明示してください。
「The bathymetric contours are derived from those contained within the GEBCO Digital Atlas, published by the BODC on behalf of IOC and IHO (2003) (http://www.gebco.net)
海上保安庁許可第292502号（水路業務法第25条に基づく類似刊行物）」
Shoreline data is derived from: United States. National Imagery and Mapping Agency. "Vector Map Level 0 (VMAP0)." Bethesda, MD: Denver, CO: The Agency; USGS Information Services, 1997.

![scr1](https://user-images.githubusercontent.com/688044/65712202-2663b000-e09f-11e9-8fd2-e6c8dc7615bf.jpg)
