### PR TITLE
Added mapy.cz tourist map

### DIFF
--- a/World/MapyCZ-tourist.xml
+++ b/World/MapyCZ-tourist.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.4">
+	<name>mapy.cz tourist</name>
+	<url>https://mapserver.mapy.cz/turist-m/$z-$x-$y</url>
+	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © Seznam.cz, a.s.</copyright>
+</map>


### PR DESCRIPTION
mazpy.cz tourist map is a good alternative to OpenTopoMap.
[Frequently asked questions about Mapy.cz](https://napoveda.seznam.cz/cz/caste-dotazy-k-mapam/)
[License conditions](https://napoveda.seznam.cz/cz/licencni-podminky-mapovych-podkladu/)