### PR TITLE
Added OpenTopoMap.ru

### DIFF
--- a/World/Europe/RU/OpenTopoMap.xml
+++ b/World/Europe/RU/OpenTopoMap.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<map xmlns="http://www.gpxsee.org/map/1.4">
+	<name>OpenTopoMap.ru</name>
+	<url>https://tile-a.opentopomap.ru/$z/$x/$y.png</url>
+	<zoom max="18"/>
+	<copyright>Map data: © OpenStreetMap contributors (ODbL), SRTM | Map style: © OpenTopoMap, OpenTopoap.ru (CC-BY-SA)</copyright>
+</map>


### PR DESCRIPTION
What is different from OpenTopoMap.org:
* Coverage: ex-USSR and Czech Republic.
* A lot of improvements in the style (see https://forum.openstreetmap.org/viewtopic.php?id=68308)