### PR TITLE
Fix Finnish maps

### DIFF
--- a/World/Europe/FI/Ilmakuva.xml
+++ b/World/Europe/FI/Ilmakuva.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
 	<name>Ilmakuva (Aerial image)</name>
-	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
+	<url type="REST">https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/WMTSCapabilities.xml</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
 	<format>image/jpeg</format>
 	<layer>ortokuva</layer>

--- a/World/Europe/FI/Maastokartta.xml
+++ b/World/Europe/FI/Maastokartta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
 	<name>Maastokartta (Topographic map)</name>
-	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
+	<url type="REST">https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/WMTSCapabilities.xml</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
 	<layer>maastokartta</layer>
 	<set>ETRS-TM35FIN</set>

--- a/World/Europe/FI/Selkokartta.xml
+++ b/World/Europe/FI/Selkokartta.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
 	<name>Selkokartta (Plain map)</name>
-	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
+	<url type="REST">https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/WMTSCapabilities.xml</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
 	<layer>selkokartta</layer>
 	<set>ETRS-TM35FIN</set>

--- a/World/Europe/FI/Taustakartta.xml
+++ b/World/Europe/FI/Taustakartta.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
-	<name>Rinnevarjostus (Hillshade)</name>
-	<url>https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c</url>
+	<name>Taustakartta (Background map)</name>
+	<url type="REST">https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/WMTSCapabilities.xml</url>
 	<copyright>Map data: National Land Survey of Finland (CC BY 4.0)</copyright>
-	<layer>korkeusmalli_vinovalo</layer>
+	<layer>taustakartta</layer>
 	<set>ETRS-TM35FIN</set>
 </map>


### PR DESCRIPTION
WMTS service moved from `https://retkikartta.fi/wmts/30c616a00f157e7357721900e8b0415c` to `https://maps-mml.anderscloud.com/wmts`, but I didn't managed to get it work with GPXSee:
```sh
$ curl 'https://maps-mml.anderscloud.com/wmts/?ngsw-bypass=1&Service=WMTS&Request=GetCapabilities'
<html>
<head>
<META NAME="robots" CONTENT="noindex,nofollow">
<script src="/_Incapsula_Resource?SWJIYLWA=5074a744e2e3d891814e9a2dace20bd4,719d34d31c8e3a6e6fffd425f7e032f3">
</script>
<body>
</body></html>
```
While [GetCapabilities](https://maps-mml.anderscloud.com/wmts/?ngsw-bypass=1&Service=WMTS&Request=GetCapabilities) works from browser.
So, to get it fixed, I've switched to REST `https://avoin-karttakuva.maanmittauslaitos.fi/avoin/wmts/1.0.0/WMTSCapabilities.xml`, but there is no hillshade (korkeusmalli_vinovalo) layer there.