### PR TITLE
Update licence for tiles from openstreetmap.org

### DIFF
--- a/World/OpenStreetMap.xml
+++ b/World/OpenStreetMap.xml
@@ -2,5 +2,5 @@
 <map xmlns="http://www.gpxsee.org/map/1.4">
 	<name>Open Street Map</name>
 	<url>https://tile.openstreetmap.org/$z/$x/$y.png</url>
-	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © OpenStreetMap (CC-BY-SA)</copyright>
+	<copyright>Map data: © OpenStreetMap contributors (ODbL) | Rendering: © OpenStreetMap (CC-BY 4.0)</copyright>
 </map>


### PR DESCRIPTION
[New licence for the “standard style” tiles from openstreetmap.org](https://blog.openstreetmap.org/2020/06/25/new-licence-for-the-standard-style-tiles-from-openstreetmap-org/) (TLDR: CC BY-SA 2.0 -> CC BY 4.0)