### PR TITLE
fixup some IGN maps after the move to data.geopf.fr

### DIFF
--- a/World/Europe/FR/IGN-maps-scan-oaci-vfr.tpl
+++ b/World/Europe/FR/IGN-maps-scan-oaci-vfr.tpl
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
     <name>Carte OACI-VFR</name>
-    <url>https://wxs.ign.fr/insert-your-apikey-here/geoportail/wmts</url>
+    <url>https://data.geopf.fr/private/wmts?apikey=your-key</url>
     <copyright>IGN Géoportail / Organisation de l'aviation civile internationale</copyright>
     <format>image/jpeg</format>
     <layer>GEOGRAPHICALGRIDSYSTEMS.MAPS.SCAN-OACI</layer>

--- a/World/Europe/FR/IGN-maps.xml
+++ b/World/Europe/FR/IGN-maps.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
 	<name>Cartes IGN</name>
-	<url>https://wxs.ign.fr/pratique/geoportail/wmts</url>
+	<url>https://data.geopf.fr/wmts</url>
 	<copyright>Institut national de l’information géographique et forestière</copyright>
 	<layer>GEOGRAPHICALGRIDSYSTEMS.PLANIGNV2</layer>
 	<style>normal</style>
-	<set>PM</set>
+	<set>PM_0_19</set>
 </map>

--- a/World/Europe/FR/IGN-orthophotos.xml
+++ b/World/Europe/FR/IGN-orthophotos.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <map xmlns="http://www.gpxsee.org/map/1.4" type="WMTS">
 	<name>Photographies aériennes</name>
-	<url>https://wxs.ign.fr/pratique/geoportail/wmts</url>
+	<url>https://data.geopf.fr/wmts</url>
 	<copyright>Institut national de l’information géographique et forestière</copyright>
 	<format>image/jpeg</format>
 	<layer>ORTHOIMAGERY.ORTHOPHOTOS</layer>
 	<style>normal</style>
-	<set>PM</set>
+	<set>PM_0_19</set>
 </map>


### PR DESCRIPTION
i dunno for the scan oaci layer as i dont use it, but for the other two that variant works fine here. Many more layers can be added from the same WMTS if needed.

cf https://geoservices.ign.fr/services-web-issus-des-scans-ign and https://geoservices.ign.fr/services-web-essentiels (sorry, french only)

i guess the PR will automagically update https://maps.gpxsee.org ?